### PR TITLE
fix download image command in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,14 +60,14 @@ Build requires about 2.5 GB of free space available.
 You can build it by issuing the following commands::
 
     sudo apt-get install realpath qemu-user-static
-    
+
     git clone https://github.com/guysoft/FullPageOS.git
     cd FullPageOS/src/image
-    curl -J -O -L  http://downloads.raspberrypi.org/raspbian_latest
+    curl -J -O -L  http://downloads.raspberrypi.org/raspbian_latest > latest-raspbian.zip
     cd ..
     sudo modprobe loop
     sudo bash -x ./build
-    
+
 Building FullPageOS Variants
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -76,7 +76,7 @@ FullPageOS supports building variants, which are builds with changes from the ma
 To build a variant use::
 
     sudo bash -x ./build [Variant]
-    
+
 Building Using Vagrant
 ~~~~~~~~~~~~~~~~~~~~~~
 There is a vagrant machine configuration to let build FullPageOS in case your build environment behaves differently. Unless you do extra configuration, vagrant must run as root to have nfs folder sync working.
@@ -93,7 +93,7 @@ After provisioning the machine, its also possible to run a nightly build which u
 
     cd FullPageOS/src/vagrant
     run_vagrant_build.sh
-    
+
 To build a variant on the machine simply run:
 
     cd FullPageOS/src/vagrant

--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,10 @@ You can build it by issuing the following commands::
 
     sudo apt-get install realpath qemu-user-static
 
+
     git clone https://github.com/guysoft/FullPageOS.git
     cd FullPageOS/src/image
-    curl -J -O -L  http://downloads.raspberrypi.org/raspbian_latest > latest-raspbian.zip
+    curl -JLO http://downloads.raspberrypi.org/raspbian_latest
     cd ..
     sudo modprobe loop
     sudo bash -x ./build
@@ -76,6 +77,7 @@ FullPageOS supports building variants, which are builds with changes from the ma
 To build a variant use::
 
     sudo bash -x ./build [Variant]
+
 
 Building Using Vagrant
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -93,6 +95,7 @@ After provisioning the machine, its also possible to run a nightly build which u
 
     cd FullPageOS/src/vagrant
     run_vagrant_build.sh
+
 
 To build a variant on the machine simply run:
 

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,6 @@ You can build it by issuing the following commands::
 
     sudo apt-get install realpath qemu-user-static
 
-
     git clone https://github.com/guysoft/FullPageOS.git
     cd FullPageOS/src/image
     curl -JLO http://downloads.raspberrypi.org/raspbian_latest
@@ -77,7 +76,6 @@ FullPageOS supports building variants, which are builds with changes from the ma
 To build a variant use::
 
     sudo bash -x ./build [Variant]
-
 
 Building Using Vagrant
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -95,7 +93,6 @@ After provisioning the machine, its also possible to run a nightly build which u
 
     cd FullPageOS/src/vagrant
     run_vagrant_build.sh
-
 
 To build a variant on the machine simply run:
 

--- a/src/config
+++ b/src/config
@@ -30,7 +30,11 @@ fi
 [ -n "$FULLPAGEOS_SCRIPT_PATH" ] || FULLPAGEOS_SCRIPT_PATH=$CONFIG_DIR
 [ -n "$FULLPAGEOS_IMAGE_PATH" ] || FULLPAGEOS_IMAGE_PATH=$FULLPAGEOS_SCRIPT_PATH/image
 
-[ -n "$FULLPAGEOS_ZIP_IMG" ] || FULLPAGEOS_ZIP_IMG=`ls -t $FULLPAGEOS_IMAGE_PATH/*-raspbian*.zip | head -n 1`
+if [ -f ${FULLPAGEOS_IMAGE_PATH}/raspbian_latest ]; then
+  mv ${FULLPAGEOS_IMAGE_PATH}/raspbian_latest ${FULLPAGEOS_IMAGE_PATH}/latest-raspbian.zip
+fi
+
+[ -n "$FULLPAGEOS_ZIP_IMG" ] || FULLPAGEOS_ZIP_IMG=$(ls -t ${FULLPAGEOS_IMAGE_PATH}/*-raspbian*.zip | head -n 1)
 
 [ -n "$FULLPAGEOS_WORKSPACE" ] || FULLPAGEOS_WORKSPACE=$FULLPAGEOS_SCRIPT_PATH/workspace$WORKSPACE_POSTFIX
 [ -n "$FULLPAGEOS_CHROOT_SCRIPT_PATH" ] || FULLPAGEOS_CHROOT_SCRIPT_PATH=$FULLPAGEOS_SCRIPT_PATH/chroot_script
@@ -39,7 +43,7 @@ fi
 # if set will enlarge root parition prior to build by provided size in MB
 [ -n "$FULLPAGEOS_IMAGE_ENLARGEROOT" ] || FULLPAGEOS_IMAGE_ENLARGEROOT=1000
 
-# if set will resize root partition on image after build to minimum size + 
+# if set will resize root partition on image after build to minimum size +
 # provided size in MB
 [ -n "$FULLPAGEOS_IMAGE_RESIZEROOT" ] || FULLPAGEOS_IMAGE_RESIZEROOT=200
 


### PR DESCRIPTION
When following the readme i get a file "./scr/image/raspbian_latest".
With this file the buildscript does not work because it can't find the zip.
This pull fixes the filename.