### PR TITLE
Add --disable-session-crashed-bubble to startup

### DIFF
--- a/src/filesystem/home/pi/scripts/start_chromium_browser
+++ b/src/filesystem/home/pi/scripts/start_chromium_browser
@@ -1,2 +1,2 @@
 #!/bin/bash
-chromium-browser --kiosk --touch-events=enabled --disable-pinch --noerrdialogs --app=$(head -n 1 /boot/fullpageos.txt)
+chromium-browser --kiosk --touch-events=enabled --disable-pinch --noerrdialogs --disable-session-crashed-bubble --app=$(head -n 1 /boot/fullpageos.txt)


### PR DESCRIPTION
Adds --disable-session-crashed-bubble to prevent the "Chromium did not shut down correctly, restore pages?" prompt. 

Fixes https://github.com/guysoft/FullPageOS/issues/89