### PR TITLE
Create a safe_refresh script

### DIFF
--- a/src/modules/fullpageos/filesystem/home/pi/scripts/safe_refresh
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/safe_refresh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script attempts a refresh, but only if the requested page returns successfully.
+
+url="$(cat /boot/fullpageos.txt)"
+
+curl --fail "$url" &> /dev/null
+curlRetr="$?"
+
+if [[ "$curlRetr" -ne "0" ]]; then
+  echo "Waiting to refresh since server is having issues.";
+  exit 1;
+fi
+
+echo "Refreshing page.";
+
+export DISPLAY=:0
+WID=$(xdotool search --onlyvisible --class chromium|head -1)
+xdotool windowactivate ${WID}
+xdotool key ctrl+F5
+
+xdotool key F11


### PR DESCRIPTION
This script is the same as refresh, but first checks the requested url.

This first checks the server to ensure that the page can be loaded successfully.

Suggested use would be periodically in cron, to keep the page up to date. However, if the server goes down, a refresh would result in a blank page, looking bad to end users, potentially for quite a long time, if you only run a refresh, for example, once per hour.

Instead, using this script in cron will ensure that scheduled page refreshes never refresh to a bad page, or at least drastically reduces the chance. 