### PR TITLE
Auto refresh added on log errors [WIP]

### DIFF
--- a/src/modules/fullpageos/filesystem/home/pi/scripts/start_chromium_browser
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/start_chromium_browser
@@ -6,7 +6,7 @@ exit;
 
 # Remove the two lines above to enable signage mode - refresh the browser whenever errors are seen in log
 
-chromium-browser --enable-logging --v=1 --kiosk --touch-events=enabled --disable-pinch --noerrdialogs --disable-session-crashed-bubble --app=$(head -n 1 /boot/fullpageos.txt)
+chromium-browser --enable-logging --v=1 --kiosk --touch-events=enabled --disable-pinch --noerrdialogs --disable-session-crashed-bubble --app=$(head -n 1 /boot/fullpageos.txt) &
 
 export logfile="/home/pi/.config/chromium/chrome_debug.log"
 

--- a/src/modules/fullpageos/filesystem/home/pi/scripts/start_chromium_browser
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/start_chromium_browser
@@ -1,2 +1,22 @@
 #!/bin/bash
+
+# Standard behavior - runs chrome
 chromium-browser --kiosk --touch-events=enabled --disable-pinch --noerrdialogs --disable-session-crashed-bubble --app=$(head -n 1 /boot/fullpageos.txt)
+exit;
+
+# Remove the two lines above to enable signage mode - refresh the browser whenever errors are seen in log
+
+chromium-browser --enable-logging --v=1 --kiosk --touch-events=enabled --disable-pinch --noerrdialogs --disable-session-crashed-bubble --app=$(head -n 1 /boot/fullpageos.txt)
+
+export logfile="/home/pi/.config/chromium/chrome_debug.log"
+
+
+# Refreshes after a crash by watching logs
+tail -n 0 -f "$logfile" | while read LOGLINE &> /dev/null; do
+
+   echo "Refreshing after crash"
+   echo "Restarting at `date` after a reported crash. Logline: ${LOGLINE}" >> /tmp/crashlog
+   [[ "${LOGLINE}" == *"ERROR"* ]] && /home/pi/scripts/refresh
+
+done
+


### PR DESCRIPTION
While this is a bit of a brute force instrument, this adds the option to have the tab auto refresh on errors in the logs (typically generated from crashes).

This is good for signage applications where you never want a user to see a crashed tab, and you'd rather have it restart automatically.