### PR TITLE
Changed realpath to coreutils

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ FullPageOS can be built from Debian, Ubuntu, Raspbian, or even FullPageOS.
 Build requires about 2.5 GB of free space available.
 You can build it by issuing the following commands::
 
-    sudo apt-get install realpath p7zip-full qemu-user-static
+    sudo apt install coreutils p7zip-full qemu-user-static
     
     git clone https://github.com/guysoft/CustomPiOS.git
     git clone https://github.com/guysoft/FullPageOS.git


### PR DESCRIPTION
The realpath package no longer exists, the coreutils package now contains it.
Also changed apt-get to apt, as its the new version of apt