### PR TITLE
Disables overscroll-history-navigation

### DIFF
--- a/src/modules/fullpageos/filesystem/home/pi/scripts/start_chromium_browser
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/start_chromium_browser
@@ -8,7 +8,7 @@ exit;
 
 # Remove the two lines above to enable signage mode - refresh the browser whenever errors are seen in log
 
-chromium-browser --enable-logging --log-level=2 --v=0 --kiosk --touch-events=enabled --disable-pinch --noerrdialogs --disable-session-crashed-bubble --app=$(head -n 1 /boot/fullpageos.txt | sed -e "s/{serial}/${SERIAL}/g") &
+chromium-browser --enable-logging --log-level=2 --v=0 --kiosk --touch-events=enabled --disable-pinch --noerrdialogs --disable-session-crashed-bubble --disable-pinch --overscroll-history-navigation=0 --app=$(head -n 1 /boot/fullpageos.txt | sed -e "s/{serial}/${SERIAL}/g") &
 
 export logfile="/home/pi/.config/chromium/chrome_debug.log"
 


### PR DESCRIPTION
This disables going back and forth in the browser history using touch gestures, when using a touchscreen or touchpad