### PR TITLE
Use systemd for vnc

### DIFF
--- a/src/modules/fullpageos/filesystem/home/pi/scripts/run_onepageos
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/run_onepageos
@@ -1,5 +1,5 @@
 #!/bin/bash
-x11vnc -many -rfbauth /home/pi/.vnc/passwd &
+
 while true
 do
     if [ $(curl -sL -w "%{http_code}\\n" "http://localhost/FullPageDashboard" -o /dev/null) == "200" ] || grep -q disabled "/boot/check_for_httpd" ; then

--- a/src/modules/fullpageos/filesystem/root_init/etc/systemd/system/x11vnc.service
+++ b/src/modules/fullpageos/filesystem/root_init/etc/systemd/system/x11vnc.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=VNC Server for X11
+ConditionPathExists=/home/pi/.vnc/passwd
+Requires=display-manager.service
+
+[Service]
+ExecStart=/usr/bin/x11vnc -display :0 -auth guess -many -noxdamage -rfbauth /home/pi/.vnc/passwd -rfbport 5900 -shared
+ExecStop=/usr/bin/x11vnc -R stop
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/src/modules/fullpageos/start_chroot_script
+++ b/src/modules/fullpageos/start_chroot_script
@@ -124,6 +124,9 @@ then
     fi
 fi
 
+#Enable x11vnc service
+systemctl enable x11vnc.service
+
 #echo "sudo -u pi startx /home/pi/scripts/run_onepageos &" >> /etc/rc.local
 #echo "(sleep 15 ; sudo -u pi /home/pi/scripts/fullscreen) &" >> /etc/rc.local
 


### PR DESCRIPTION
Using systemd for startup and run control makes vnc more stable. I exoerienced x11vnc crashes sometimes, systemd will restart the service automatically. 
