### PR TITLE
Added Github action to build image for tagged releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,56 @@
+name: Build Image
+
+on:
+  pull_request: {}
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Dependencies
+      run: sudo apt install coreutils p7zip-full qemu-user-static
+    - name: Checkout CustomPiOS
+      uses: actions/checkout@v2
+      with:
+        repository: 'guysoft/CustomPiOS'
+        path: CustomPiOS
+    - name: Checkout Project Repository
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ github.repository }}
+        path: repository
+    - name: Download Raspbian Image
+      run: cd repository/src/image && wget -q -c --trust-server-names 'https://downloads.raspberrypi.org/raspbian_lite_latest'
+    - name: Update CustomPiOS Paths
+      run: cd repository/src && ../../CustomPiOS/src/update-custompios-paths
+    - name: Build Image
+      run: sudo modprobe loop && cd repository/src && sudo bash -x ./build_dist
+    - name: Copy Output
+      run: cp ${{ github.workspace }}/repository/src/workspace/*-raspbian-buster-lite.img build.img
+    - name: Zip Output
+      run: gzip build.img
+    - uses: actions/upload-artifact@v1
+      with:
+        name: build.img.gz
+        path: build.img.gz
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+    - name: Upload Release
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: build.img.gz
+        asset_name: build.img.gz
+        asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         repository: ${{ github.repository }}
         path: repository
+        submodules: true
     - name: Download Raspbian Image
       run: cd repository/src/image && wget -q -c --trust-server-names 'https://downloads.raspberrypi.org/raspbian_lite_latest'
     - name: Update CustomPiOS Paths

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,6 @@
 name: Build Image
 
-on:
-  pull_request: {}
-  push:
-    tags:
-      - v*
+on: push
 
 jobs:
   build:
@@ -37,21 +33,3 @@ jobs:
       with:
         name: build.img.gz
         path: build.img.gz
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@latest
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-    - name: Upload Release
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: build.img.gz
-        asset_name: build.img.gz
-        asset_content_type: application/octet-stream


### PR DESCRIPTION
This adds the necessary config to build a raspberry pi image and create a github release for any push tagged with a version number.