### PR TITLE
URL-Handling / .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ src/build.log
 src/vagrant/.vagrant/*
 src/vagrant/*.log
 src/workspace/*
+src/workspace*/*
+src/variants/*
+!src/variants/no-acceleration

--- a/src/modules/fullpageos/filesystem/home/pi/scripts/get_url
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/get_url
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SERIAL=`cat /proc/cpuinfo | grep -i '^Serial' | awk '{ print $3 }'`
+URL="$(head -n 1 /boot/fullpageos.txt | sed -e "s/{serial}/${SERIAL}/g")"
+echo $URL

--- a/src/modules/fullpageos/filesystem/home/pi/scripts/run_onepageos
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/run_onepageos
@@ -2,7 +2,7 @@
 
 while true
 do
-    if [ $(curl -sL -w "%{http_code}\\n" "http://localhost/FullPageDashboard" -o /dev/null) == "200" ] || grep -q disabled "/boot/check_for_httpd" ; then
+    if [ $(curl -sL -w "%{http_code}\\n" "$(/home/pi/scripts/get_url)" -o /dev/null) == "200" ] || grep -q disabled "/boot/check_for_httpd" ; then
       (sleep 15 ; /home/pi/scripts/fullscreen) &
       xdotool mousemove 9000 9000
       %BROWSER_START_SCRIPT%

--- a/src/modules/fullpageos/filesystem/home/pi/scripts/safe_refresh
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/safe_refresh
@@ -2,9 +2,7 @@
 
 # This script attempts a refresh, but only if the requested page returns successfully.
 
-url="$(cat /boot/fullpageos.txt)"
-
-curl --fail "$url" &> /dev/null
+curl --fail "$(/home/pi/scripts/get_url)" &> /dev/null
 curlRetr="$?"
 
 if [[ "$curlRetr" -ne "0" ]]; then

--- a/src/modules/fullpageos/filesystem/home/pi/scripts/start_chromium_browser
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/start_chromium_browser
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-SERIAL=`cat /proc/cpuinfo | grep -i '^Serial' | awk '{ print $3 }'`
-
 # Standard behavior - runs chrome
-chromium-browser --kiosk --touch-events=enabled --disable-pinch --noerrdialogs --disable-session-crashed-bubble --simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT' --disable-component-update --overscroll-history-navigation=0 --disable-features=TranslateUI --app=$(head -n 1 /boot/fullpageos.txt | sed -e "s/{serial}/${SERIAL}/g")
+chromium-browser --kiosk --touch-events=enabled --disable-pinch --noerrdialogs --disable-session-crashed-bubble --simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT' --disable-component-update --overscroll-history-navigation=0 --disable-features=TranslateUI --app=$(/home/pi/scripts/get_url)
 exit;
 
 # Remove the two lines above to enable signage mode - refresh the browser whenever errors are seen in log


### PR DESCRIPTION
This PR addresses a few issues I found while working on a custom variant of fullpageos.

##### .gitignore file 
The gitignore file is updated to ignore custom variants (except for the example variant) as well as workspaces of custom variants.

##### url handling
Multiple scripts use some type of URL with quite a few different ways this is handled:

* `run_onepageos` has the following URL hardcoded: `http://localhost/FullPageDashboard`
    * This prevents fullpageos from working if FullPageDashboard or the local webserver is not included in the image
* `safe_refresh` uses `$(cat /boot/fullpageos.txt)`
    * This might cause issues / inconsistent behaviour if there is more than one line in the `fullpageos.txt` (I did not test if that actually causes issues but replaced it regardless)
* `start_chromium_browser` uses `$(head -n 1 /boot/fullpageos.txt | sed -e "s/{serial}/${SERIAL}/g"`
    * This is what is now used in the `get_url` script