### PR TITLE
Improve chrome refesh after a crash

### DIFF
--- a/src/modules/fullpageos/filesystem/home/pi/scripts/refresh
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/refresh
@@ -1,5 +1,6 @@
 #!/bin/bash
 export DISPLAY=:0
+sleep 1
 WID=$(xdotool search --onlyvisible --class chromium|head -1)
 xdotool windowactivate ${WID}
 xdotool key ctrl+F5

--- a/src/modules/fullpageos/filesystem/home/pi/scripts/start_chromium_browser
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/start_chromium_browser
@@ -12,7 +12,7 @@ export logfile="/home/pi/.config/chromium/chrome_debug.log"
 
 
 # Refreshes after a crash by watching logs
-tail -n 0 -f "$logfile" | while read LOGLINE &> /dev/null; do
+tail -n 0 -F "$logfile" | while read LOGLINE &> /dev/null; do
 
    echo "Refreshing after crash"
    echo "Restarting at `date` after a reported crash. Logline: ${LOGLINE}" >> /tmp/crashlog


### PR DESCRIPTION
Since chrome_debug.log is re-created by chrome when it start. tail should use the -F flag instead of the -f flag.
https://unix.stackexchange.com/questions/410471/tail-f-but-when-the-file-is-deleted-and-re-created-not-appended

I suggest also to add a 1 second delay before refeshing chrome after a crash.