### PR TITLE
Enable cookies in curl pre-start check

### DIFF
--- a/src/modules/fullpageos/filesystem/home/pi/scripts/run_onepageos
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/run_onepageos
@@ -2,7 +2,7 @@
 
 while true
 do
-    if [[ $(curl -sL -w "%{http_code}\\n" "$(/home/pi/scripts/get_url)" -o /dev/null) =~ ^([23][0-9]{2,2}|401)$ ]] || grep -q disabled "/boot/check_for_httpd" ; then
+    if [[ $(curl -sL -b cookiefile -w "%{http_code}\\n" "$(/home/pi/scripts/get_url)" -o /dev/null) =~ ^([23][0-9]{2,2}|401)$ ]] || grep -q disabled "/boot/check_for_httpd" ; then
       xdotool mousemove 9000 9000
       %BROWSER_START_SCRIPT%
     fi


### PR DESCRIPTION
Hey folks,

I faced a problem related to curl not configured to use cookies in the pre-start check. This may only be relevant to you if you use couple of redirects and session stuff for your display.

Kind regards
Tobias