### PR TITLE
Add user-agent (curl)

### DIFF
--- a/src/modules/fullpageos/filesystem/home/pi/scripts/run_onepageos
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/run_onepageos
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+USER_AGENT="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36"
+
 while true
 do
-    if [[ $(curl -sL -b cookiefile -w "%{http_code}\\n" "$(/home/pi/scripts/get_url)" -o /dev/null) =~ ^([23][0-9]{2,2}|401)$ ]] || grep -q disabled "/boot/check_for_httpd" ; then
+    if [[ $(curl -sL -b cookiefile -w "%{http_code}\\n" -H "user-agent: ${USER_AGENT}" "$(/home/pi/scripts/get_url)" -o /dev/null) =~ ^([23][0-9]{2,2}|401)$ ]] || grep -q disabled "/boot/check_for_httpd" ; then
       xdotool mousemove 9000 9000
       %BROWSER_START_SCRIPT%
     fi

--- a/src/modules/fullpageos/filesystem/home/pi/scripts/run_onepageos
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/run_onepageos
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-USER_AGENT="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36"
+USER_AGENT="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 
 while true
 do


### PR DESCRIPTION
While trying to create a simple clock kiosk using this site: https://time.is/clock/Moscow found, that in case `curl` requests are forbidden:
```bash
curl -sL -b cookiefile -w "%{http_code}\\n"  https://time.is/clock/Moscow -o /dev/null
403
```

Details:
```bash
curl -L https://time.is/clock/Moscow
<h1 style="font-family:sans-serif;padding:20px">Please do not scrape our pages! Thanks!</h1>
```

This is confusing, I didn’t even immediately understand why I only had a black screen and a mouse cursor, found this related issue: https://github.com/guysoft/FullPageOS/issues/405

Maybe this will be helpfull for someone else.