### PR TITLE
Page refresh update

### DIFF
--- a/src/modules/fullpageos/filesystem/home/pi/scripts/refresh
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/refresh
@@ -4,5 +4,3 @@ sleep 1
 WID=$(xdotool search --onlyvisible --class chromium|head -1)
 xdotool windowactivate ${WID}
 xdotool key ctrl+F5
-
-xdotool key F11

--- a/src/modules/fullpageos/filesystem/home/pi/scripts/safe_refresh
+++ b/src/modules/fullpageos/filesystem/home/pi/scripts/safe_refresh
@@ -16,5 +16,3 @@ export DISPLAY=:0
 WID=$(xdotool search --onlyvisible --class chromium|head -1)
 xdotool windowactivate ${WID}
 xdotool key ctrl+F5
-
-xdotool key F11


### PR DESCRIPTION
xdotool key F11 is no longer required. 

Refresh doesn't take the browser out of full screen anymore, with  
'xdotool key F11' in place it cycles fullscreen on and off.