### PR TITLE
Fix Chromium process not being killed

### DIFF
--- a/src/modules/fullpageos/filesystem/opt/custompios/scripts/reload_fullpageos_txt
+++ b/src/modules/fullpageos/filesystem/opt/custompios/scripts/reload_fullpageos_txt
@@ -1,2 +1,2 @@
 #!/bin/bash
-killall chromium
+killall /usr/lib/chromium/chromium

--- a/src/modules/fullpageos/filesystem/opt/custompios/scripts/reload_fullpageos_txt
+++ b/src/modules/fullpageos/filesystem/opt/custompios/scripts/reload_fullpageos_txt
@@ -1,2 +1,2 @@
 #!/bin/bash
-killall /usr/lib/chromium-browser/chromium-browser
+killall chromium


### PR DESCRIPTION
Hello there, while I was trying the OS I noticed that the script located in `src/modules/fullpageos/filesystem/opt/custompios/scripts/reload_fullpageos_txt` was not working, returning this error:

```bash
/usr/lib/chromium-browser/chromium-browser: No such file or directory
```

So, I fixed this by replacing the absolute path with the process name only.

**Edit:** typo