### PR TITLE
replace {hostname} with the $HOSTNAME system variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Features
 * Loads Chromium at boot in full screen
 * Webpage can be changed from /boot/firmware/fullpageos.txt
     * You can use variable `{serial}` in the url to get device's serialnumber in the URL
+    * You can use variable `{hostname}` in the URL to get device's hostname in the URL
 * Default app is `FullPageDashboard <https://github.com/amitdar/FullPageDashboard>`_, which lets you add multiple tabs changes that switch automatically.
 * Ships with preconfigured `X11VNC <http://www.karlrunge.com/x11vnc/>`_, for remote connection (password 'raspberry')
 * Specify a custom Splashscreen that gets displayed in the booting process instead of Kernel messages/text

--- a/src/modules/fullpageos/filesystem/opt/custompios/scripts/get_url
+++ b/src/modules/fullpageos/filesystem/opt/custompios/scripts/get_url
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 SERIAL=`cat /proc/cpuinfo | grep -i '^Serial' | awk '{ print $3 }'`
-URL="$(head -n 1 /boot/firmware/fullpageos.txt | sed -e "s/{serial}/${SERIAL}/g")"
+URL="$(head -n 1 /boot/fullpageos.txt | sed -e "s/{serial}/${SERIAL}/g" | sed -e "s/{hostname}/${HOSTNAME}/")"
 echo $URL


### PR DESCRIPTION
Use the variable `{hostname}` in the URL of `/boot/firmware/fullpageos.txt` to make use of the Raspi's hostname in the URL. This works similar to the `{serial}` variable.