### PR TITLE
Low memory error popup on Pi Zero 2 W prevents boot

### DIFF
--- a/src/modules/fullpageos/filesystem/opt/custompios/scripts/start_chromium_browser
+++ b/src/modules/fullpageos/filesystem/opt/custompios/scripts/start_chromium_browser
@@ -5,6 +5,7 @@ flags=(
    --touch-events=enabled
    --disable-pinch
    --noerrdialogs
+   --no-memcheck
    --disable-session-crashed-bubble
    --simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT'
    --disable-component-update


### PR DESCRIPTION
When loading FullpageOS on a Pi Zero 2 W (512MB) RAM, an error dialog pops up on boot saying it is not recommended to run Chromium on less than 1GB RAM.
This error dialog prevents the completion of the boot process until you connect a mouse to click OK. This wouldn't be ideal for my clients when they reboot their displays and have no knowledge of Pi's and cannot load their marketing screens.

This Chromium flag prevents the memory check, and the FullpageOS system boots properly on low memory Pi's without needing to connect peripherals to clear the error.