### PR TITLE
Rename chromium-browser to chromium, package was renamed in latest Pi OS

### DIFF
--- a/src/modules/fullpageos/filesystem/opt/custompios/scripts/start_chromium_browser
+++ b/src/modules/fullpageos/filesystem/opt/custompios/scripts/start_chromium_browser
@@ -16,12 +16,12 @@ flags=(
 )
 
 # Standard behavior - runs chromium
-chromium-browser "${flags[@]}" --app=$(/opt/custompios/scripts/get_url)
+chromium "${flags[@]}" --app=$(/opt/custompios/scripts/get_url)
 exit;
 
 # Remove the two lines above to enable signage mode - refresh the browser whenever errors are seen in log
 
-chromium-browser --enable-logging --log-level=2 --v=0 "${flags[@]}" --app=$(/opt/custompios/scripts/get_url) &
+chromium --enable-logging --log-level=2 --v=0 "${flags[@]}" --app=$(/opt/custompios/scripts/get_url) &
 
 export logfile="/home/$(id -nu 1000)/.config/chromium/chrome_debug.log"
 

--- a/src/modules/fullpageos/start_chroot_script
+++ b/src/modules/fullpageos/start_chroot_script
@@ -38,7 +38,7 @@ apt-get -y --force-yes install git screen checkinstall avahi-daemon libavahi-com
 
 if [ "$FULLPAGEOS_INCLUDE_CHROMIUM" == "yes" ]
 then
-    apt-get install -y --force-yes chromium-browser
+    apt-get install -y --force-yes chromium
     sed -i 's@%BROWSER_START_SCRIPT%@/opt/custompios/scripts/start_chromium_browser@g' /opt/custompios/scripts/run_onepageos
 fi
 


### PR DESCRIPTION
This fixes the build, which is broken because this package was renamed in the latest version of Raspberry Pi OS.