### PR TITLE
e2e: wait for dashboard QR content before final screenshot

### DIFF
--- a/testing/hooks/screenshot.sh
+++ b/testing/hooks/screenshot.sh
@@ -5,7 +5,13 @@ export E2E_SSH_PORT="${2:-2222}"
 ARTIFACTS_DIR="${3:-/output}"
 source /test/scripts/ssh-helpers.sh
 SCREENSHOT_URL="${SCREENSHOT_URL:-http://localhost/FullPageDashboard}"
-PAINT_STDDEV_THRESHOLD="${PAINT_STDDEV_THRESHOLD:-0.08}"
+# The FullPageOS desktop wallpaper / dashboard shell alone paints at stddev
+# ~0.20, while the welcome dashboard with the QR code paints at ~0.31. Require
+# the higher value so we don't accept the wallpaper after the kiosk restarts
+# (e.g. following test_translation_disabled.sh), and wait for the welcome
+# iframe content to actually render.
+PAINT_STDDEV_THRESHOLD="${PAINT_STDDEV_THRESHOLD:-0.26}"
+PAINT_STABLE_PASSES="${PAINT_STABLE_PASSES:-2}"
 
 echo "Capturing X display screenshot from the running desktop..."
 
@@ -76,16 +82,26 @@ dashboard_is_painted() {
 }
 
 echo "  Waiting for dashboard iframe content to paint..."
+consecutive_passes=0
 for i in $(seq 1 60); do
     if capture_display_png "$ARTIFACTS_DIR/screenshot-candidate.png"; then
         cp "$ARTIFACTS_DIR/screenshot-candidate.png" "$ARTIFACTS_DIR/screenshot-not-painted.png"
         if dashboard_is_painted "$ARTIFACTS_DIR/screenshot-candidate.png"; then
-            mv "$ARTIFACTS_DIR/screenshot-candidate.png" "$ARTIFACTS_DIR/screenshot.png"
-            rm -f "$ARTIFACTS_DIR/screenshot-not-painted.png"
-            echo "Display screenshot saved after dashboard paint (${i}x2s)"
-            exit 0
+            consecutive_passes=$((consecutive_passes + 1))
+            if [ "$consecutive_passes" -ge "$PAINT_STABLE_PASSES" ]; then
+                mv "$ARTIFACTS_DIR/screenshot-candidate.png" "$ARTIFACTS_DIR/screenshot.png"
+                rm -f "$ARTIFACTS_DIR/screenshot-not-painted.png"
+                echo "Display screenshot saved after dashboard paint (${consecutive_passes} stable passes, ${i}x2s)"
+                exit 0
+            fi
+            echo "  Painted but waiting for stabilization (${consecutive_passes}/${PAINT_STABLE_PASSES})"
+            sleep 3
+            continue
+        else
+            consecutive_passes=0
         fi
     else
+        consecutive_passes=0
         echo "  Candidate capture failed (${i}x2s)"
     fi
     sleep 2

--- a/testing/tests/test_translation_disabled.sh
+++ b/testing/tests/test_translation_disabled.sh
@@ -40,11 +40,31 @@ ORIG_URL=$(ssh_cmd "cat ${FULLPAGEOS_TXT} 2>/dev/null || true" 2>/dev/null || tr
 echo "  Current URL: ${ORIG_URL:-<empty>}"
 
 restore_url() {
+    local restored_url="${ORIG_URL:-http://localhost/FullPageDashboard}"
     echo "  Restoring original kiosk URL..."
-    if [ -n "$ORIG_URL" ]; then
-        ssh_cmd "printf '%s\n' \"$ORIG_URL\" | sudo tee ${FULLPAGEOS_TXT} >/dev/null" 2>/dev/null || true
-    fi
+    ssh_cmd "printf '%s\n' '${restored_url}' | sudo tee ${FULLPAGEOS_TXT} >/dev/null" 2>/dev/null || true
     ssh_cmd "killall chromium 2>/dev/null || true; exit 0" || true
+
+    # run_onepageos respawns chromium from fullpageos.txt, but the new kiosk
+    # process appearing does not mean its window has composited. Wait for the
+    # dashboard kiosk process to come back so screenshot.sh starts from a
+    # relaunched kiosk rather than the bare desktop wallpaper.
+    echo "  Waiting for dashboard kiosk to relaunch on ${restored_url}..."
+    local restored=0
+    for i in $(seq 1 60); do
+        local kiosk
+        kiosk=$(ssh_cmd "ps ax -o pid= -o args= | grep -F 'chromium' | grep -F -- '--kiosk' | grep -F -- '--app=${restored_url}' | grep -v grep || true" 2>/dev/null || true)
+        if [ -n "$kiosk" ]; then
+            restored=1
+            echo "  Dashboard kiosk restored (pid: $(echo "$kiosk" | awk '{print $1}' | head -1)) after ${i}x2s"
+            break
+        fi
+        sleep 2
+    done
+    if [ "$restored" -eq 0 ]; then
+        echo "  WARNING: Dashboard kiosk did not relaunch on ${restored_url}"
+        ssh_cmd "pgrep -a chromium || true" 2>/dev/null || true
+    fi
 }
 
 echo "  Pointing kiosk at German test page..."


### PR DESCRIPTION
## Problem

The final E2E screenshot captured the **desktop wallpaper / logo** (stddev `~0.20`) instead of the welcome dashboard with the QR code (stddev `~0.31`). Tests still reported `ALL TESTS PASSED`, so the regression was silent.

Root cause (deterministic, not flaky — reproduced twice with identical stddev `0.20752`):

1. Tests run alphabetically, so `test_translation_disabled.sh` is the **last test before `screenshot.sh`**.
2. Its `restore_url()` writes the dashboard URL back to `fullpageos.txt`, `killall chromium`, then **returns without waiting for the kiosk to relaunch**. `run_onepageos` respawns chromium, but the relaunched kiosk first paints the desktop shell/wallpaper and only later loads the welcome iframe (the QR code).
3. `screenshot.sh` accepts a candidate as soon as `dashboard_is_painted` is true, but `PAINT_STDDEV_THRESHOLD` was `0.08` — and the **shell/wallpaper-only state already scores `0.20752`**, so it passed on the very first candidate before the QR iframe painted.

Stddev measurements (cropped `1280x620+0+80`, same as the hook):
- shell/logo only: `0.20752`
- German test page: `0.123093`
- full dashboard with QR: `0.312033`
- old threshold: `0.08`

## Fix

**`testing/hooks/screenshot.sh`**
- Raise `PAINT_STDDEV_THRESHOLD` default `0.08` → `0.26` (above the wallpaper/shell baseline `0.20`, below the full QR dashboard `0.31`).
- Require **two consecutive** passing captures (`PAINT_STABLE_PASSES=2`) so the screenshot is taken only after the welcome iframe has rendered and settled, not on a mid-load transition. On timeout the hook still fails and saves `screenshot-not-painted.png`.

**`testing/tests/test_translation_disabled.sh`**
- `restore_url()` now waits for the dashboard kiosk process to relaunch on the original URL (`--kiosk --app=http://localhost/FullPageDashboard`) before returning, so `screenshot.sh` starts from a relaunched kiosk rather than the bare desktop.

## Evidence

Verified against CustomPiOS PR #274 (`pr-274-local` image) + FullPageOS `devel` (`7c9b93d`), QEMU aarch64.

**Before** (`e2e_results/pr274-devel-rerun-20260713/`, unchanged `devel`):
- `screenshot.png` = desktop wallpaper / logo, stddev `0.20752`
- accepted on first candidate: `Display screenshot saved after dashboard paint (1x2s)`
- `TEST_RESULT=0`, `exit-code 0` (false pass)

**After** (`e2e_results/pr274-devel-qrfix-20260713/`, this branch):
- `restore_url`: `Dashboard kiosk restored (pid: 8480) after 2x2s`
- paint loop: `stddev 0` → `0.312033` → `Painted but waiting for stabilization (1/2)` → `0.312033` → `Display screenshot saved after dashboard paint (2 stable passes, 3x2s)`
- `screenshot.png` = welcome dashboard with QR code + setup speech bubble, stddev `0.312033`
- `TEST_RESULT=0`, `exit-code 0`, `ALL TESTS PASSED`

The fix is on the FullPageOS side only; no CustomPiOS changes.

## Test plan
- [x] Re-ran E2E on unchanged `devel` to confirm the wallpaper screenshot reproduces (not flaky)
- [x] Rebuilt E2E container with the fix and re-ran; final screenshot shows QR dashboard (stddev `0.312033`)
- [ ] Confirm CI on this PR reproduces the QR-dashboard screenshot